### PR TITLE
修复ffmpeg推流成功，但vlc播放失败。

### DIFF
--- a/protocol/rtmp.go
+++ b/protocol/rtmp.go
@@ -1562,6 +1562,10 @@ func (v *RtmpConnection) identifyCreateStream(p0, p1 *RtmpCreateStreamPacket) (c
 
 			connType, streamName, duration, err = v.identifyCreateStream(current, p)
 			return
+		default :
+			connType, streamName, duration, err = v.Identify()
+			return
+
 		}
 		return
 	})


### PR DESCRIPTION
修复ffmpeg推流成功，但vlc播放失败。
