### PR TITLE
PortPool: add check port before alloc

### DIFF
--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -24,55 +24,57 @@ SOFTWARE.
 
 package main
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestPortPool_Alloc(t *testing.T) {
-	p := NewPortPool(1, 10)
+	p := NewPortPool(6001, 6010)
 
 	if _, err := p.Alloc(0); err == nil {
 		t.Error("should error")
 	}
 
 	if ps, err := p.Alloc(1); err != nil {
-		t.Errorf("alloc failed, err is %v", err)
-	} else if len(ps) != 1 || ps[0] != 1 {
-		t.Errorf("alloc failed, ports=%v", ps)
+		t.Errorf("alloc 1 failed, err is %v", err)
+	} else if len(ps) != 1 || ps[0] != 6001 {
+		t.Errorf("alloc 1 failed, ports=%v", ps)
 	} else if ps, err = p.Alloc(9); err != nil {
-		t.Errorf("alloc failed, err is %v", err)
-	} else if len(ps) != 9 || ps[0] != 2 || ps[8] != 10 {
-		t.Errorf("alloc failed, ports=%v", ps)
+		t.Errorf("alloc 9 failed, err is %v", err)
+	} else if len(ps) != 9 || ps[0] != 6002 || ps[8] != 6010 {
+		t.Errorf("alloc 9 failed, ports=%v", ps)
 	} else if ps, err = p.Alloc(1); err == nil {
 		t.Errorf("should error, ports=%v", ps)
 	}
 }
 
 func TestPortPool_Free(t *testing.T) {
-	p := NewPortPool(1, 10)
+	p := NewPortPool(6001, 6010)
 
-	if ps, err := p.Alloc(10); err != nil || len(ps) != 10 || ps[0] != 1 || ps[9] != 10 {
+	if ps, err := p.Alloc(10); err != nil || len(ps) != 10 || ps[0] != 6001 || ps[9] != 6010 {
 		t.Errorf("alloc failed, ports=%v, err is %v", ps, err)
 	}
-	p.Free(11)
-	if ps, err := p.Alloc(1); err != nil || len(ps) != 1 || ps[0] != 11 {
+	p.Free(6010)
+	if ps, err := p.Alloc(1); err != nil || len(ps) != 1 {
 		t.Error("free failed, ports=%v, err is %v", ps, err)
-	} else if ps[0] != 11 {
+	} else if ps[0] != 6010 {
 		t.Errorf("invalid port=%v", ps)
 	}
 }
 
 func TestPortPool_Alloc2(t *testing.T) {
-	p := NewPortPool(1, 100)
+	p := NewPortPool(9001, 9100)
 
-	if ps, err := p.Alloc(64); err != nil || len(ps) != 64 || ps[0] != 1 || ps[63] != 64 {
+	if ps, err := p.Alloc(64); err != nil || len(ps) != 64 || ps[0] != 9001 || ps[63] != 9064 {
 		t.Errorf("alloc failed, ports=%v, err is %v", ps, err)
-	} else if ps, err := p.Alloc(36); err != nil || len(ps) != 36 || ps[0] != 65 || ps[35] != 100 {
+	} else if ps, err := p.Alloc(36); err != nil || len(ps) != 36 || ps[0] != 9065 || ps[35] != 9100 {
 		t.Errorf("alloc failed, ports=%v, err is %v", ps, err)
 	} else if ps, err = p.Alloc(1); err == nil {
 		t.Errorf("should error, ports=%v", ps)
 	}
 
-	p.Free(11)
-	if ps, err := p.Alloc(1); err != nil || len(ps) != 1 || ps[0] != 11 {
+	p.Free(9011)
+	if ps, err := p.Alloc(1); err != nil || len(ps) != 1 || ps[0] != 9011 {
 		t.Errorf("alloc failed, ports=%v, err is %v", ps, err)
 	} else if ps, err = p.Alloc(1); err == nil {
 		t.Errorf("should error, ports=%v", ps)


### PR DESCRIPTION
- 申请端口前增加端口检查功能.
- 每次申请端口从 v.ports 头部开始申请.
- 释放端口放到 v.ports 头部, 这样充分复用端口, 让整个程序占用的端口范围更小.
